### PR TITLE
YouTube extraction not working.

### DIFF
--- a/YoutubeExtractor/app/src/main/java/com/naveed/ytextractor/model/YTMedia.java
+++ b/YoutubeExtractor/app/src/main/java/com/naveed/ytextractor/model/YTMedia.java
@@ -16,17 +16,11 @@ public class YTMedia
 	double approxDurationMs;
 	int audioChannels;
 	int audioSampleRate;
-	String cipher;
+	String signatureCipher;
 	String audioQuality;
 	String url;
 	int fps;
-	boolean isVideo;
 
-	
-	public boolean isVideo() {
-		return getMimeType().contains("video");
-	}
-	
 	public void setFps(int fps) {
 		this.fps = fps;
 	}
@@ -34,9 +28,6 @@ public class YTMedia
 	public int getFps() {
 		return fps;
 	}
-	
-	
-
 
 	public void setItag(int itag)
 	{
@@ -178,14 +169,14 @@ public class YTMedia
 		return audioSampleRate;
 	}
 
-	public void setCipher(String cipher)
+	public void setSignatureCipher(String signatureCipher)
 	{
-		this.cipher = cipher;
+		this.signatureCipher = signatureCipher;
 	}
 
-	public String getCipher()
+	public String getSignatureCipher()
 	{
-		return cipher;
+		return signatureCipher;
 	}
 
 	public void setAudioQuality(String audioQuality)
@@ -207,11 +198,11 @@ public class YTMedia
 	{
 		return url;
 	}
-	
+
 	public boolean useCipher(){
-		
-		return (cipher!=null && cipher.contains("s="));
-		
+
+		return (signatureCipher !=null && signatureCipher.contains("s="));
+
 	}
-	
+
 }

--- a/YoutubeExtractor/app/src/main/java/com/naveed/ytextractor/utils/Utils.java
+++ b/YoutubeExtractor/app/src/main/java/com/naveed/ytextractor/utils/Utils.java
@@ -3,6 +3,8 @@ package com.naveed.ytextractor.utils;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.util.Log;
+
 import com.naveed.ytextractor.model.YTMedia;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +36,7 @@ public class Utils {
 
 	public static boolean isListContain(List<String> arraylist, String statement) {
 		for (String str : arraylist) {
-			if (statement.toLowerCase().contains(str)) {
+			if (statement != null && statement.toLowerCase().contains(str)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
So I encounter an issue where `adaptive` & `muxed` streams are returning null `url` parameter. All other parameter were working fine.

**Source:**
It seems like there was a problem while parsing JSON since mainly YouTube has changed their notation for `cipher` object as `signatureCipher`. This only difference was causing `YTMedia` returning null `url`. 

**Fix:**
I am submitting a PR that fixes this issue. I've tested it myself and it had fix the issue (extraction is working again). Consider merging this request. :)